### PR TITLE
Tell travis to install gosu dependencies before running the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ rvm:
 before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -qq build-essential freeglut3-dev libfreeimage-dev libgl1-mesa-dev libopenal-dev libpango1.0-dev libsdl-ttf2.0-dev libsndfile-dev libxinerama-dev
-script: rspec spec
+script:
+ - bundle exec rspec spec/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 rvm:
   - 2.1.0
+before_install:
+ - sudo apt-get update -qq
+ - sudo apt-get install -qq build-essential freeglut3-dev libfreeimage-dev libgl1-mesa-dev libopenal-dev libpango1.0-dev libsdl-ttf2.0-dev libsndfile-dev libxinerama-dev
 script: rspec spec


### PR DESCRIPTION
Added C++/Ruby dependencies for gosu on linux, mostly based on [gosu wiki](https://github.com/jlnr/gosu/wiki/Getting-Started-on-Linux)

Fixes #35
