### PR TITLE
Refactor gui_spec.rb to solve issue #29

### DIFF
--- a/spec/fake_gui.rb
+++ b/spec/fake_gui.rb
@@ -1,0 +1,29 @@
+require 'gosu'
+require 'gui'
+
+class FakeGosuWindow
+  def stub(*args)
+    true
+  end
+
+  alias initialize    stub
+  alias draw_quad     stub
+  alias draw_triangle stub
+  alias rotate        stub
+end
+
+GosuWindowBackup = Gosu::Window
+Gosu.send(:remove_const, :Window)
+Gosu::Window = FakeGosuWindow
+
+GuiBackup = Gui
+self.class.send(:remove_const, :Gui)
+
+load 'gui.rb' # reload gui.rb after stubbing
+
+FakeGui = Gui # catch the stubbed gui
+
+self.class.send(:remove_const, :Gui)
+Gui = GuiBackup # restore things
+Gosu.send(:remove_const, :Window)
+Gosu::Window = GosuWindowBackup

--- a/spec/gui_spec.rb
+++ b/spec/gui_spec.rb
@@ -1,4 +1,5 @@
-require 'gosu' # so it'll not be required again on gui.rb
+require 'gosu'
+require 'gui'
 
 class FakeGosuWindow
   def stub(*args)
@@ -11,10 +12,22 @@ class FakeGosuWindow
   alias rotate        stub
 end
 
+GosuWindowBackup = Gosu::Window
 Gosu.send(:remove_const, :Window)
 Gosu::Window = FakeGosuWindow
 
-require 'gui'
+GuiBackup = Gui
+self.class.send(:remove_const, :Gui)
+
+load 'gui.rb' # reload gui.rb after stubbing
+
+FakeGui = Gui # catch the stubbed gui
+
+self.class.send(:remove_const, :Gui)
+Gui = GuiBackup # restore things
+Gosu.send(:remove_const, :Window)
+Gosu::Window = GosuWindowBackup
+
 require 'arena'
 require 'ai'
 require 'robot'
@@ -22,7 +35,7 @@ require 'robot'
 describe Gui do
   before(:all) do
     @arena  = Arena.new
-    @gui    = Gui.new(@arena)
+    @gui    = FakeGui.new(@arena)
     @ai     = Ai.new(robot: nil, command_parser: nil)
     @robot  = Robot.new(heading: 0,
                        radar_heading: 0,

--- a/spec/gui_spec.rb
+++ b/spec/gui_spec.rb
@@ -1,15 +1,20 @@
 # temporary moved out of the test suite
 # https://github.com/mrhead/ruby_arena/issues/29
 require 'gui'
+require 'arena'
 
 describe Gui do
+  before(:all) do
+    @arena = Arena.new
+  end
+
   describe 'public interface' do
     it { expect(gui).to respond_to(:draw) }
   end
 
   describe '#update' do
     it 'notifies arena' do
-      expect(arena).to receive(:update)
+      expect(@arena).to receive(:update)
 
       gui.update
     end
@@ -36,11 +41,7 @@ describe Gui do
   end
 
   def gui
-    @_gui ||= Gui.new(arena)
-  end
-
-  def arena
-    @_arena ||= double('arena', width: 800, height: 600, robots: [robot], bullets: [bullet])
+    @_gui ||= Gui.new(@arena)
   end
 
   def robot

--- a/spec/gui_spec.rb
+++ b/spec/gui_spec.rb
@@ -2,11 +2,27 @@
 # https://github.com/mrhead/ruby_arena/issues/29
 require 'gui'
 require 'arena'
+require 'ai'
+require 'robot'
 
 describe Gui do
   before(:all) do
     @arena = Arena.new
     @gui    = Gui.new(@arena)
+    @ai     = Ai.new(robot: nil, command_parser: nil)
+    @robot  = Robot.new(heading: 0,
+                       radar_heading: 0,
+                       gun_heading: 0,
+                       x: 0,
+                       y: 0,
+                       size: 10,
+                       radar_view_angle: 10,
+                       radar_range: 100,
+                       ai: Ai,
+                       arena: @arena)
+    @bullet = Bullet.new(heading: 0, x: 0, y: 0, size: 2, origin: @robot, arena: @arena)
+    @arena.add_robot(@robot)
+    @arena.add_bullet(@bullet)
   end
 
   describe 'public interface' do
@@ -39,22 +55,5 @@ describe Gui do
 
       @gui.draw
     end
-  end
-
-  def robot
-    @_robot ||= double('robot',
-                       heading: 0,
-                       radar_heading: 0,
-                       gun_heading: 0,
-                       x: 0,
-                       y: 0,
-                       size: 10,
-                       radar_view_angle: 10,
-                       radar_range: 100
-                      )
-  end
-
-  def bullet
-    @_bullet ||= double('bullet', heading: 0, x: 0, y: 0, size: 2)
   end
 end

--- a/spec/gui_spec.rb
+++ b/spec/gui_spec.rb
@@ -4,25 +4,20 @@ require 'ai'
 require 'robot'
 
 describe Gui do
-  before(:all) do
-    @arena  = Arena.new
-    @gui    = FakeGui.new(@arena)
-    @ai     = Ai.new(robot: nil, command_parser: nil)
-    @robot  = Robot.new(heading: 0,
+  before(:each) do
+    @robot  = double('robot',
+                       heading: 0,
                        radar_heading: 0,
                        gun_heading: 0,
                        x: 0,
                        y: 0,
                        size: 10,
                        radar_view_angle: 10,
-                       radar_range: 100,
-                       ai: Ai,
-                       arena: @arena)
-    @bullet = Bullet.new(heading: 0, x: 0, y: 0, size: 2, origin: @robot, arena: @arena)
-    @arena.add_robot(@robot)
-    @arena.add_bullet(@bullet)
-    @robot_renderer  = @gui.send(:robot_renderer,  @robot)
-    @bullet_renderer = @gui.send(:bullet_renderer, @bullet)
+                       radar_range: 100
+                      )
+    @bullet = double('bullet', heading: 0, x: 0, y: 0, size: 2)
+    @arena  = double('arena', width: 800, height: 600, robots: [@robot], bullets: [@bullet])
+    @gui    = FakeGui.new(@arena)
   end
 
   describe 'public interface' do
@@ -39,13 +34,19 @@ describe Gui do
 
   describe '#draw' do
     it 'notifies each robot renderer' do
-      expect(@robot_renderer).to receive(:draw)
+      robot_renderer = double('robot_renderer')
+      allow(RobotRenderer).to receive(:new) { robot_renderer }
+
+      expect(robot_renderer).to receive(:draw)
 
       @gui.draw
     end
 
     it 'notifies each bullet renderer' do
-      expect(@bullet_renderer).to receive(:draw)
+      bullet_renderer = double('bullet_renderer')
+      allow(BulletRenderer).to receive(:new) { bullet_renderer }
+
+      expect(bullet_renderer).to receive(:draw)
 
       @gui.draw
     end

--- a/spec/gui_spec.rb
+++ b/spec/gui_spec.rb
@@ -1,3 +1,19 @@
+require 'gosu' # so it'll not be required again on gui.rb
+
+class FakeGosuWindow
+  def stub(*args)
+    true
+  end
+
+  alias initialize    stub
+  alias draw_quad     stub
+  alias draw_triangle stub
+  alias rotate        stub
+end
+
+Gosu.send(:remove_const, :Window)
+Gosu::Window = FakeGosuWindow
+
 require 'gui'
 require 'arena'
 require 'ai'

--- a/spec/gui_spec.rb
+++ b/spec/gui_spec.rb
@@ -1,34 +1,30 @@
 require 'fake_gui'
-require 'arena'
-require 'ai'
-require 'robot'
 
 describe Gui do
-  before(:each) do
-    @robot  = double('robot',
-                       heading: 0,
-                       radar_heading: 0,
-                       gun_heading: 0,
-                       x: 0,
-                       y: 0,
-                       size: 10,
-                       radar_view_angle: 10,
-                       radar_range: 100
-                      )
-    @bullet = double('bullet', heading: 0, x: 0, y: 0, size: 2)
-    @arena  = double('arena', width: 800, height: 600, robots: [@robot], bullets: [@bullet])
-    @gui    = FakeGui.new(@arena)
+  let(:robot) do
+    double('robot',
+            heading: 0,
+            radar_heading: 0,
+            gun_heading: 0,
+            x: 0,
+            y: 0,
+            size: 10,
+            radar_view_angle: 10,
+            radar_range: 100 )
   end
+  let(:bullet) { double('bullet', heading: 0, x: 0, y: 0, size: 2) }
+  let(:arena)  { double('arena', width: 800, height: 600, robots: [robot], bullets: [bullet]) }
+  let(:gui)    { FakeGui.new(arena) }
 
   describe 'public interface' do
-    it { expect(@gui).to respond_to(:draw) }
+    it { expect(gui).to respond_to(:draw) }
   end
 
   describe '#update' do
     it 'notifies arena' do
-      expect(@arena).to receive(:update)
+      expect(arena).to receive(:update)
 
-      @gui.update
+      gui.update
     end
   end
 
@@ -39,7 +35,7 @@ describe Gui do
 
       expect(robot_renderer).to receive(:draw)
 
-      @gui.draw
+      gui.draw
     end
 
     it 'notifies each bullet renderer' do
@@ -48,7 +44,7 @@ describe Gui do
 
       expect(bullet_renderer).to receive(:draw)
 
-      @gui.draw
+      gui.draw
     end
   end
 end

--- a/spec/gui_spec.rb
+++ b/spec/gui_spec.rb
@@ -6,17 +6,18 @@ require 'arena'
 describe Gui do
   before(:all) do
     @arena = Arena.new
+    @gui    = Gui.new(@arena)
   end
 
   describe 'public interface' do
-    it { expect(gui).to respond_to(:draw) }
+    it { expect(@gui).to respond_to(:draw) }
   end
 
   describe '#update' do
     it 'notifies arena' do
       expect(@arena).to receive(:update)
 
-      gui.update
+      @gui.update
     end
   end
 
@@ -27,7 +28,7 @@ describe Gui do
 
       expect(robot_renderer).to receive(:draw)
 
-      gui.draw
+      @gui.draw
     end
 
     it 'notifies each bullet renderer' do
@@ -36,12 +37,8 @@ describe Gui do
 
       expect(bullet_renderer).to receive(:draw)
 
-      gui.draw
+      @gui.draw
     end
-  end
-
-  def gui
-    @_gui ||= Gui.new(@arena)
   end
 
   def robot

--- a/spec/gui_spec.rb
+++ b/spec/gui_spec.rb
@@ -1,33 +1,4 @@
-require 'gosu'
-require 'gui'
-
-class FakeGosuWindow
-  def stub(*args)
-    true
-  end
-
-  alias initialize    stub
-  alias draw_quad     stub
-  alias draw_triangle stub
-  alias rotate        stub
-end
-
-GosuWindowBackup = Gosu::Window
-Gosu.send(:remove_const, :Window)
-Gosu::Window = FakeGosuWindow
-
-GuiBackup = Gui
-self.class.send(:remove_const, :Gui)
-
-load 'gui.rb' # reload gui.rb after stubbing
-
-FakeGui = Gui # catch the stubbed gui
-
-self.class.send(:remove_const, :Gui)
-Gui = GuiBackup # restore things
-Gosu.send(:remove_const, :Window)
-Gosu::Window = GosuWindowBackup
-
+require 'fake_gui'
 require 'arena'
 require 'ai'
 require 'robot'

--- a/spec/gui_spec.rb
+++ b/spec/gui_spec.rb
@@ -1,5 +1,3 @@
-# temporary moved out of the test suite
-# https://github.com/mrhead/ruby_arena/issues/29
 require 'gui'
 require 'arena'
 require 'ai'
@@ -7,7 +5,7 @@ require 'robot'
 
 describe Gui do
   before(:all) do
-    @arena = Arena.new
+    @arena  = Arena.new
     @gui    = Gui.new(@arena)
     @ai     = Ai.new(robot: nil, command_parser: nil)
     @robot  = Robot.new(heading: 0,

--- a/spec/gui_spec.rb
+++ b/spec/gui_spec.rb
@@ -23,6 +23,8 @@ describe Gui do
     @bullet = Bullet.new(heading: 0, x: 0, y: 0, size: 2, origin: @robot, arena: @arena)
     @arena.add_robot(@robot)
     @arena.add_bullet(@bullet)
+    @robot_renderer  = @gui.send(:robot_renderer,  @robot)
+    @bullet_renderer = @gui.send(:bullet_renderer, @bullet)
   end
 
   describe 'public interface' do
@@ -39,19 +41,13 @@ describe Gui do
 
   describe '#draw' do
     it 'notifies each robot renderer' do
-      robot_renderer = double('robot_renderer')
-      allow(RobotRenderer).to receive(:new) { robot_renderer }
-
-      expect(robot_renderer).to receive(:draw)
+      expect(@robot_renderer).to receive(:draw)
 
       @gui.draw
     end
 
     it 'notifies each bullet renderer' do
-      bullet_renderer = double('bullet_renderer')
-      allow(BulletRenderer).to receive(:new) { bullet_renderer }
-
-      expect(bullet_renderer).to receive(:draw)
+      expect(@bullet_renderer).to receive(:draw)
 
       @gui.draw
     end


### PR DESCRIPTION
I'm beginner on RSpec. 
So don't merge it before discussing the issue with someone more experienced than me.
I just made this pull request to "show" this code and put it on discussion.

The reasoning of this pull request of mine is:
- I thought the issue was overcomplicated using doubles (mocks/stubs)
- As a beginner on RSpec I thought Mocks/Stubs were more useful when "faking" something that you can't instantiate at test time or at least is too long (execution time) or unreliable as database access, file writings, internet comunications. So I couldn't see the point in "doubling" things that you should instantiate (at almost the same execution time cost as "doubling" it).
- Perhaps the advantage of double is to "isolate" each test and test ONLY that particular thing you're wanting too. For example, if I have some problem on Gui class all 4 examples will fail, when you probably would want it to fail on ONLY one particular test, as the others don't rely on the actual object but rely on a double. Is it what you are willing to accomplish?

**Update** - discussed and now using doubles and let.
